### PR TITLE
Disable CRC check

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -74,7 +74,7 @@ static const unsigned freqs[] = { 400000, 300000, 200000, 100000 };
  * performance cost, and for other reasons may not always be desired.
  * So we allow it it to be disabled.
  */
-bool use_spi_crc = 1;
+bool use_spi_crc = 0;
 module_param(use_spi_crc, bool, 0);
 
 /*


### PR DESCRIPTION
Software CRC checking can reduce performance by up to 30%, so we turned it off for better performance.